### PR TITLE
Update README.md for helm > 3.0

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -26,7 +26,7 @@ helm init --service-account tiller
 Starting from 3.0, tiller has been removed. There is no need to create a service account for tiller anymore. The only command that is mandatory is the helm repo add command below:
 
 ```
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 ```
 
 ## Setup S3 helm repository


### PR DESCRIPTION
Update the repo path to solve below error:
helm repo add stable https://kubernetes-charts.storage.googleapis.com/
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead